### PR TITLE
Support new versions of Flask-SQLAlchemy

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-Flask-SQLAlchemy==1.0
+Flask-SQLAlchemy==2.2
 Sphinx==1.1.3


### PR DESCRIPTION
This should fix the issue where the `connection_stack` binding isn't available after the 2.2 release of Flask-SQLAlchemy.